### PR TITLE
Add skylight level filter

### DIFF
--- a/src/main/java/net/pcal/mobfilter/MFConfig.java
+++ b/src/main/java/net/pcal/mobfilter/MFConfig.java
@@ -64,6 +64,7 @@ public class MFConfig {
         public String[] blockId;
         public String[] timeOfDay;
         public String[] lightLevel;
+        public String[] skylightLevel;
         public Integer[] moonPhase;
 
         // for backwards compatibility:

--- a/src/main/java/net/pcal/mobfilter/MFRules.java
+++ b/src/main/java/net/pcal/mobfilter/MFRules.java
@@ -9,6 +9,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -236,6 +237,16 @@ abstract class MFRules {
             int val = req.serverWorld.getMaxLocalRawBrightness(req.blockPos);
             boolean isMatch = min <= val && val <= max;
             req.logger().trace(() -> "[MobFilter]     LightLevelCheck " + min + " <= " + val + " <= " + max+ " " +isMatch);
+            return isMatch;
+        }
+    }
+
+    record SkylightLevelCheck(int min, int max) implements FilterCheck {
+        @Override
+        public boolean isMatch(SpawnRequest req) {
+            int val = req.serverWorld.getBrightness(LightLayer.SKY, req.blockPos);
+            boolean isMatch = min <= val && val <= max;
+            req.logger().trace(() -> "[MobFilter]     SkylightLevelCheck " + min + " <= " + val + " <= " + max+ " " +isMatch);
             return isMatch;
         }
     }

--- a/src/main/java/net/pcal/mobfilter/MFService.java
+++ b/src/main/java/net/pcal/mobfilter/MFService.java
@@ -20,6 +20,7 @@ import net.pcal.mobfilter.MFRules.FilterRule;
 import net.pcal.mobfilter.MFRules.FilterRuleList;
 import net.pcal.mobfilter.MFRules.LightLevelCheck;
 import net.pcal.mobfilter.MFRules.MoonPhaseCheck;
+import net.pcal.mobfilter.MFRules.SkylightLevelCheck;
 import net.pcal.mobfilter.MFRules.SpawnReasonCheck;
 import net.pcal.mobfilter.MFRules.SpawnRequest;
 import net.pcal.mobfilter.MFRules.TimeOfDayCheck;
@@ -236,6 +237,10 @@ public class MFService {
             if (when.lightLevel != null) {
                 int[] range = parseRange(when.lightLevel);
                 checks.add(new LightLevelCheck(range[0], range[1]));
+            }
+            if (when.skylightLevel != null) {
+                int[] range = parseRange(when.skylightLevel);
+                checks.add(new SkylightLevelCheck(range[0], range[1]));
             }
             if (when.moonPhase != null) {
                 checks.add(new MoonPhaseCheck(Matcher.of(when.moonPhase)));


### PR DESCRIPTION
This PR adds a skylightLevel when condition.

Skylight is a special kind of light that represents a block's exposure to the sky. A block directly under the sky will have a skylight of 15, *even during the night*. Opaque blocks will stop the spread of skylight and some blocks such as water or leaves will reduce it. You can check the skylight levels on the f3 debug screen.  https://minecraft.wiki/w/Light#Sky_light

![image](https://github.com/user-attachments/assets/4f88102a-4e27-472e-b4d8-2049e333dd18)

Checking the skylight is useful as a condition for mob spawning because it allows you to stop spawns on the surface no matter how high or low the surface is. 

# An example

```json5
    {
      name : 'Peaceful surface',
      what : 'DISALLOW_SPAWN',
      when : {
        category : [ 'MONSTER' ],
        dimensionId : [ 'minecraft:overworld' ],
        skylightLevel : [ 1, 15 ],
        spawnReason : [ 'NATURAL' ]
      }
    }
```
This stops monsters from spawning on the surface - anywhere exposed to the sky. If you dig out a chunk to y -50, it will stop mobs from spawning there! If you have mountains with caves at y 120, monsters will spawn there! This image uses the rule above. 
![image](https://github.com/user-attachments/assets/c63e007a-d005-4b77-8843-338943fea2c0)

