### PR TITLE
Backport skylightLevel and fail-loudly-behaviour to 1.20.1

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -68,6 +68,11 @@ You can match all blocks in a given namespace using `*`; for example `minecraft:
 #### `lightLevel`
 Two integers between 0 and 16.  True if mob is spawning in a lightLevel within the range.
 
+#### `skylightLevel`
+Two integers 0 and 15, inclusive.  True if a mob is spawning on a block whose
+[Sky Light level](https://minecraft.wiki/w/Light#Sky_light) is within the range.
+Rule only exists for Minecraft versions 1.20.1 and above.
+
 #### `moonPhase`
 List of integers between 1 (Full Moon) and 8, inclusive, [indicating a phase of the moon](https://minecraft.fandom.com/wiki/Moon).
 True if mob is spawning when the moon is at a phase number that is in the list.
@@ -246,6 +251,25 @@ prevent specific mobs from spawning.
       when : {
         category : [ 'MONSTER' ],
         moonPhase : [ 1 ]
+      }
+    }
+  ]
+}
+```
+
+### Peaceful Surface
+*This stops monsters from spawning on the surface - anywhere exposed to the sky.*
+```
+{
+  rules : [
+    {
+      name : 'Peaceful surface',
+      what : 'DISALLOW_SPAWN',
+      when : {
+        category : [ 'MONSTER' ],
+        dimensionId : [ 'minecraft:overworld' ],
+        skylightLevel : [ 1, 15 ],
+        spawnReason : [ 'NATURAL' ]
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,25 @@ See [CONFIG.md](https://github.com/pcal43/mob-filter/blob/main/CONFIG.md) for mo
 }
 ```
 
+### Peaceful Surface
+*This stops monsters from spawning on the surface - anywhere exposed to the sky.*
+```
+{
+  rules : [
+    {
+      name : 'Peaceful surface',
+      what : 'DISALLOW_SPAWN',
+      when : {
+        category : [ 'MONSTER' ],
+        dimensionId : [ 'minecraft:overworld' ],
+        skylightLevel : [ 1, 15 ],
+        spawnReason : [ 'NATURAL' ]
+      }
+    }
+  ]
+}
+```
+
 
 ## Why This Mod?
 

--- a/src/main/java/net/pcal/mobfilter/MFConfig.java
+++ b/src/main/java/net/pcal/mobfilter/MFConfig.java
@@ -56,6 +56,7 @@ public class MFConfig {
         public String[] blockId;
         public String[] timeOfDay;
         public String[] lightLevel;
+        public String[] skylightLevel;
         public Integer[] moonPhase;
     }
 }

--- a/src/main/java/net/pcal/mobfilter/MFConfig.java
+++ b/src/main/java/net/pcal/mobfilter/MFConfig.java
@@ -2,6 +2,9 @@ package net.pcal.mobfilter;
 
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.MobSpawnType;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -10,6 +13,7 @@ import org.yaml.snakeyaml.constructor.Constructor;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -26,8 +30,22 @@ public class MFConfig {
 
     static Configuration loadFromJson(final InputStream in) throws IOException {
         final String rawJson = new String(in.readAllBytes(), StandardCharsets.UTF_8);
-        final Gson gson = new Gson();
-        return gson.fromJson(rawJson, Configuration.class);
+        final Gson gson = new GsonBuilder().setLenient().create();
+        class TypoCatchingJsonReader extends JsonReader {
+            public TypoCatchingJsonReader(StringReader in) {
+                super(in);
+                super.setLenient(true);
+            }
+
+            @Override
+            public void skipValue()  {
+                // GSon calls this to silently ignore json keys that don't bind to anything.  People then get
+                // confused about why their configuration isn't fully working.  So here we just fail loudly instead.
+                // Note we don't throw IOException because GSon tries to handle that in ways that obscure the message.
+                throw new RuntimeException("Unexpected configuration names at: "+this.getPath());
+            }
+        }
+        return gson.fromJson(new TypoCatchingJsonReader(new StringReader(rawJson)), TypeToken.get(Configuration.class));
     }
 
     public static class Configuration {

--- a/src/main/java/net/pcal/mobfilter/MFRules.java
+++ b/src/main/java/net/pcal/mobfilter/MFRules.java
@@ -9,6 +9,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -237,6 +238,16 @@ abstract class MFRules {
             int val = req.serverWorld.getMaxLocalRawBrightness(req.blockPos);
             boolean isMatch = min <= val && val <= max;
             req.logger().trace(() -> "[MobFilter]     LightLevelCheck " + min + " <= " + val + " <= " + max+ " " +isMatch);
+            return isMatch;
+        }
+    }
+
+    record SkylightLevelCheck(int min, int max) implements FilterCheck {
+        @Override
+        public boolean isMatch(SpawnRequest req) {
+            int val = req.serverWorld.getBrightness(LightLayer.SKY, req.blockPos);
+            boolean isMatch = min <= val && val <= max;
+            req.logger().trace(() -> "[MobFilter]     SkylightLevelCheck " + min + " <= " + val + " <= " + max+ " " +isMatch);
             return isMatch;
         }
     }

--- a/src/main/java/net/pcal/mobfilter/MFService.java
+++ b/src/main/java/net/pcal/mobfilter/MFService.java
@@ -20,6 +20,7 @@ import net.pcal.mobfilter.MFRules.FilterRule;
 import net.pcal.mobfilter.MFRules.FilterRuleList;
 import net.pcal.mobfilter.MFRules.LightLevelCheck;
 import net.pcal.mobfilter.MFRules.MoonPhaseCheck;
+import net.pcal.mobfilter.MFRules.SkylightLevelCheck;
 import net.pcal.mobfilter.MFRules.SpawnRequest;
 import net.pcal.mobfilter.MFRules.SpawnTypeCheck;
 import net.pcal.mobfilter.MFRules.TimeOfDayCheck;
@@ -234,6 +235,10 @@ public class MFService {
             if (when.lightLevel != null) {
                 int[] range = parseRange(when.lightLevel);
                 checks.add(new LightLevelCheck(range[0], range[1]));
+            }
+            if (when.skylightLevel != null) {
+                int[] range = parseRange(when.skylightLevel);
+                checks.add(new SkylightLevelCheck(range[0], range[1]));
             }
             if (when.moonPhase != null) {
                 checks.add(new MoonPhaseCheck(Matcher.of(when.moonPhase)));


### PR DESCRIPTION
I needed the skylightLevel rule for version 1.20.1, such I backported it. I also added the fail-loudly behaviour as I did not notice that the rule doesn't even exist in that version yet.